### PR TITLE
fix: zone compression crash/freeze

### DIFF
--- a/src/core/acts/tools/fastfile/compressors/compressor_bo4.cpp
+++ b/src/core/acts/tools/fastfile/compressors/compressor_bo4.cpp
@@ -44,7 +44,14 @@ namespace {
 
     class FFCompressorBO4 : public FFCompressor {
       public:
+        static constexpr uint32_t READ_SEGMENT = 0x800000;
+        static constexpr uint32_t ZLIB_STORED_OVERHEAD = 11;
+        static constexpr uint32_t MIN_FILLER_GAP =
+            (uint32_t)sizeof(fastfile::DBStreamHeader) + ZLIB_STORED_OVERHEAD + 4;
+        static constexpr uint32_t SAFE_MARGIN = MIN_FILLER_GAP;
+
         FFCompressorBO4() : FFCompressor("BO4", "Black ops 4 fast file compressor") {}
+
         void Init(FastFileLinkerOption& opt) override {
             constexpr size_t maxSize{ utils::GetMaxSize<int32_t>() };
             if (opt.chunkSize > maxSize) {
@@ -80,7 +87,6 @@ namespace {
             }
 
             for (fastfile::FastFile& ff : ctx.fastfiles) {
-
                 AesKeyLocal* aesKey{};
                 uint8_t aesIV[16]{};
                 uint8_t aesVal[16]{};
@@ -113,15 +119,105 @@ namespace {
                     alg,
                     chunkSize
                 );
+
                 while (remainingSize > 0) {
                     uint32_t uncompressedSize{ (uint32_t)std::min<size_t>(chunkSize, remainingSize) };
+                    uint32_t chunkStart{ (uint32_t)out.size() };
+                    uint32_t boundary{ ((chunkStart / READ_SEGMENT) + 1) * READ_SEGMENT };
 
-                    compressBuffer.clear();
-                    if (!utils::compress::CompressBuffer(alg, toCompress, uncompressedSize, compressBuffer)) {
-                        throw std::runtime_error(
-                            std::format("Can't compress chunk 0x{:x} of size 0x{:x}", idx - 1, uncompressedSize)
-                        );
+                    bool fits{ false };
+                    for (;;) {
+                        compressBuffer.clear();
+                        if (!utils::compress::CompressBuffer(alg, toCompress, uncompressedSize, compressBuffer)) {
+                            throw std::runtime_error(
+                                std::format("Can't compress chunk 0x{:x} of size 0x{:x}", idx, uncompressedSize)
+                            );
+                        }
+                        uint32_t alignedSize{ utils::Aligned<uint32_t>((uint32_t)compressBuffer.size()) };
+                        uint32_t chunkEnd{ chunkStart + (uint32_t)sizeof(fastfile::DBStreamHeader) + alignedSize };
+                        uint32_t gapAfter{ chunkEnd <= boundary ? boundary - chunkEnd : 0 };
+
+                        if (chunkEnd <= boundary && (gapAfter == 0 || gapAfter >= SAFE_MARGIN)) {
+                            fits = true;
+                            break;
+                        }
+                        if (uncompressedSize <= 1) {
+                            fits = false; // give up shrinking and don't write this attempt at all
+                            break;
+                        }
+                        uncompressedSize = (uncompressedSize + 1) / 2;
                     }
+
+                    if (!fits) {
+                        // close the entire remaining gap
+                        uint32_t gap{ boundary - chunkStart };
+                        if (gap < MIN_FILLER_GAP) {
+                            throw std::runtime_error(
+                                std::format("Dead-zone gap 0x{:x} too small to close at 0x{:x}", gap, chunkStart)
+                            );
+                        }
+                        uint32_t targetAligned{ gap - (uint32_t)sizeof(fastfile::DBStreamHeader) };
+                        uint32_t fillerInput{ targetAligned - ZLIB_STORED_OVERHEAD };
+
+                        size_t fillerCompressedSize{};
+                        std::unique_ptr<byte[]> fillerCompressed{ utils::compress::Compress(
+                            utils::compress::COMP_ZLIB | utils::compress::COMP_STORED,
+                            toCompress,
+                            fillerInput,
+                            &fillerCompressedSize
+                        ) };
+                        if (!fillerCompressed) {
+                            throw std::runtime_error("Can't build boundary filler chunk");
+                        }
+
+                        uint32_t fillerOffset{
+                            (uint32_t)utils::Allocate(out, sizeof(fastfile::DBStreamHeader) + targetAligned)
+                        };
+                        fastfile::DBStreamHeader& fh{ *(fastfile::DBStreamHeader*)&out[fillerOffset] };
+                        fh.offset = fillerOffset;
+                        fh.uncompressedSize = fillerInput;
+                        fh.compressedSize = (uint32_t)fillerCompressedSize;
+                        fh.alignedSize = targetAligned;
+
+                        byte* fillerData{ fillerCompressed.get() };
+                        if (aesKey) {
+                            symmetric_CTR ctr{};
+                            int r;
+                            if ((r = ctr_start(aesCipher, aesVal, aesKey->key, sizeof(aesKey->key), 0, 0, &ctr)) !=
+                                CRYPT_OK) {
+                                throw std::runtime_error(
+                                    std::format("Failed to start ctr {} for ff {}", error_to_string(r), ff.ffname)
+                                );
+                            }
+                            if ((r = ctr_encrypt(fillerData, fillerData, fh.compressedSize, &ctr)) != CRYPT_OK) {
+                                throw std::runtime_error(
+                                    std::format("Can't encrypt filler block 0x{:x}: {}", idx, error_to_string(r))
+                                );
+                            }
+                            *((uint64_t*)&aesVal[0]) += fh.compressedSize;
+                        }
+
+                        std::memcpy(
+                            &out[fillerOffset + sizeof(fastfile::DBStreamHeader)],
+                            fillerData,
+                            fh.compressedSize
+                        );
+
+                        toCompress += fillerInput;
+                        remainingSize -= fillerInput;
+
+                        LOG_TRACE(
+                            "filler chunk {} @ offset 0x{:x}: exact-fit stored zlib, {} src bytes, closes boundary "
+                            "0x{:x} exactly",
+                            idx,
+                            fillerOffset,
+                            fillerInput,
+                            boundary
+                        );
+                        idx++;
+                        continue;
+                    }
+
                     uint32_t alignedSize{ utils::Aligned<uint32_t>((uint32_t)compressBuffer.size()) };
                     compressedSize += compressBuffer.size();
 
@@ -139,16 +235,13 @@ namespace {
                     byte* compressedData{ compressBuffer.data() };
                     if (aesKey) {
                         symmetric_CTR ctr{};
-
                         int r;
-
                         if ((r = ctr_start(aesCipher, aesVal, aesKey->key, sizeof(aesKey->key), 0, 0, &ctr)) !=
                             CRYPT_OK) {
                             throw std::runtime_error(
                                 std::format("Failed to start ctr {} for ff {}", error_to_string(r), ff.ffname)
                             );
                         }
-
                         if ((r = ctr_encrypt(compressedData, compressedData, h.compressedSize, &ctr)) != CRYPT_OK) {
                             throw std::runtime_error(
                                 std::format("Can't encrypt block 0x{:x}: {}", idx, error_to_string(r))
@@ -165,10 +258,11 @@ namespace {
                     remainingSize -= uncompressedSize;
 
                     LOG_TRACE(
-                        "Compressed 0x{:x}->0x{:x} at chunk 0x{:x}, remaining 0x{:x}",
+                        "Compressed 0x{:x}->0x{:x} at chunk 0x{:x}, writing to: 0x{:x}, remaining 0x{:x}",
                         uncompressedSize,
                         h.compressedSize,
                         idx,
+                        blockOffset,
                         remainingSize
                     );
 
@@ -214,7 +308,7 @@ namespace {
 
                 // blocks load data
                 for (size_t i = 0; i < fastfile::linker::bo4::XFILE_BLOCK_COUNT; i++) {
-                    header.blockSize[i] = (uint64_t)ff.blockSizes[i] * 2;
+                    header.blockSize[i] = (uint64_t)ff.blockSizes[i];
                 }
 
                 // todo: write other data

--- a/src/core/shared/utils/compress_utils.cpp
+++ b/src/core/shared/utils/compress_utils.cpp
@@ -200,7 +200,9 @@ namespace utils::compress {
 #ifdef __ACTS_COMPRESS_HAS_ZLIB
         case COMP_ZLIB: {
             uLongf destSizef = (uLongf)*destSize;
-            int level{ alg & COMP_HIGH_COMPRESSION ? Z_BEST_COMPRESSION : Z_BEST_SPEED };
+            int level{ (alg & COMP_STORED)             ? Z_NO_COMPRESSION
+                       : (alg & COMP_HIGH_COMPRESSION) ? Z_BEST_COMPRESSION
+                                                       : Z_BEST_SPEED };
             if (compress2((Bytef*)dest, &destSizef, (const Bytef*)src, (uLongf)srcSize, level) != Z_OK)
                 return false;
             *destSize = destSizef;

--- a/src/core/shared/utils/compress_utils.hpp
+++ b/src/core/shared/utils/compress_utils.hpp
@@ -33,6 +33,9 @@ namespace utils::compress {
         COMP_OODLE_TYPE_HYDRA = 12ull << 9,
         COMP_OODLE_TYPE_LEVIATHAN = 13ull << 9,
         COMP_OODLE_TYPE_MASK = 15ull << 9,
+
+        // stored compression
+        COMP_STORED = 1ull << 13,
     };
 
     constexpr size_t MAX_LZ4_SIZE = 0x7E000000;


### PR DESCRIPTION
Description of this pull request:

Fix zone compression causing the game to crash or freeze while trying to allocate a huge number from DB_AllocXBlocks, this seem to happen if the zone file reaches a size (around 0x800000, causing it to always read that offset's size for the next asset to link in DB_AuthLoad_AnalyzeData from DB_LinkXAssetEntry), also removed the ``header.blockSize[i] = (uint64_t)ff.blockSizes[i] * 2;`` (multiplying by 2), i am not sure if this was important or not but it does not seem to do anything while i was testing at least 3 separate zone files with multiple assets types.

---

Please check all the lines before posting the pull request:

- I have tested all my changes
- I have formatted the code (`cmake --build build --target format`, `clang-format` is required)
- My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- All my commits have relevant names in English
- I have squashed my commits (if necessary)
