### PR TITLE
fix: zone config bool

### DIFF
--- a/src/core/acts/tools/fastfile/fastfile_zone.cpp
+++ b/src/core/acts/tools/fastfile/fastfile_zone.cpp
@@ -153,7 +153,7 @@ namespace fastfile::zone {
         if (utils::EqualIgnoreCase("true", v))
             return true;
         if (utils::EqualIgnoreCase("false", v))
-            return true;
+            return false;
         LOG_WARNING("Invalid bool value for {}: {}", name, v);
         return defaultVal;
     }


### PR DESCRIPTION
Description of this pull request:

- Small Fix for config bool in ``Zone::GetConfigBool`` returning true for the false statement.

```cpp
if (utils::EqualIgnoreCase("false", v))
    return true;
```

---

Please check all the lines before posting the pull request:

- I have tested all my changes
- I have formatted the code (`cmake --build build --target format`, `clang-format` is required)
- My pull request isn't fixing or changing multiple unlinked elements (please create one pull request for each element)
- All my commits have relevant names in English
- I have squashed my commits (if necessary)
