### PR TITLE
Fix GetLibBase reading the PE file in text mode on Windows

### DIFF
--- a/src/core/shared/platform/platform_windows.cpp
+++ b/src/core/shared/platform/platform_windows.cpp
@@ -108,7 +108,7 @@ namespace platform {
     }
 
     void* GetLibBase(const char* lib) {
-        utils::InFileCE is{ lib };
+        utils::InFileCE is{ lib, false, std::ios::in | std::ios::binary };
         if (!is) {
             return 0;
         }


### PR DESCRIPTION
utils::InFileCE is{ lib } in GetLibBase() opens the target PE with no explicit mode, so it defaults to Windows text mode: CRLF translation and 0x1A treated as EOF. That corrupts a binary read of an executable. Every other InFileCE backing a FileReader in the codebase already passes std::ios::binary; this call site was missed. One line fix, adds std::ios::in | std::ios::binary explicitly.