### PR TITLE
fix: invert m_fdIgnoreMissing test in iw decompressor

### DIFF
--- a/src/core/acts/tools/fastfile/decompressors/decompressor_iw.cpp
+++ b/src/core/acts/tools/fastfile/decompressors/decompressor_iw.cpp
@@ -462,7 +462,7 @@ namespace {
                 if (opt.ReadFile(fpfile.string(), fileFPBuff)) {
                     hasFdFile = true;
                 } else {
-                    if (opt.m_fdIgnoreMissing) {
+                    if (!opt.m_fdIgnoreMissing) {
                         throw std::runtime_error(std::format("Can't read {}", fpfile.string()));
                     }
                     fileFPBuff.clear();
@@ -474,7 +474,7 @@ namespace {
                 if (opt.ReadFile(fcfile.string(), fileFCBuff)) {
                     hasFcFile = true;
                 } else {
-                    if (opt.m_fdIgnoreMissing) {
+                    if (!opt.m_fdIgnoreMissing) {
                         throw std::runtime_error(std::format("Can't read {}", fcfile.string()));
                     }
                     fileFCBuff.clear();


### PR DESCRIPTION
-i/--fd-ignore is documented as "Ignore missing fd file", but the IW decompressor threw when the flag was set rather than when it was unset. Passing -i therefore turned a missing .fp/.fc sidecar into a hard failure, which is the opposite of the flag's purpose.

The t9 and t78 decompressors already use the correct !m_fdIgnoreMissing test, so only IW-format games were affected.